### PR TITLE
Graph構造体に辺リストを持つようにした

### DIFF
--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,5 +1,5 @@
 {
-"Test/AOJ/ALDS1_11_B.test.cpp": "2023-06-09 17:43:28 +0900",
+"Test/AOJ/ALDS1_11_B.test.cpp": "2023-06-11 22:24:39 +0900",
 "Test/AtCoder/abc172_c.test.cpp": "2023-06-07 06:12:35 +0900",
 "Test/AtCoder/abc213_c.test.cpp": "2023-06-07 04:27:59 +0900",
 "Test/AtCoder/agc023_a.test.cpp": "2023-06-07 06:12:35 +0900",

--- a/Docs/Graph/Basis/AdjacentList.md
+++ b/Docs/Graph/Basis/AdjacentList.md
@@ -100,6 +100,29 @@ inline usize sizeE() const
 
 <br />
 
+#### enumerateEdges
+```
+inline std::vector<Edge<CostType>> enumerateEdges() const
+```
+
+今までに追加した辺のリストを`std::vector`で返します。
+- `addUndirectedEdge`で作られた辺と`addDirectedEdge`で作られた辺は区別されていません。
+
+**計算量:** $O(\mid E\mid)$
+
+<br />
+
+#### getEdge
+```
+inline std::vector<E> getEdge(u32 i) const
+```
+
+$i$ 番目に追加した辺を`Edge`構造体で返します。`addUndirectedEdge`で追加された辺と`addDirectedEdge`で追加された辺は区別されません。
+
+**制約:** $0\ \le\ i\ <\ \mid E\mid$
+
+**計算量:** 定数時間
+
 ## Edge構造体について
 
 以下のようなメンバ変数を持つ構造体です。

--- a/Src/Graph/Basis/AdjacentList.hpp
+++ b/Src/Graph/Basis/AdjacentList.hpp
@@ -23,38 +23,50 @@ class AdjacentList {
 private:
     using E = Edge<CostType>;
 
-    usize N, M;
-    std::vector<std::vector<E>> G;
+    usize n, m;
+    std::vector<E> edges;
+    std::vector<std::vector<E>> g;
 
 public:
     AdjacentList() = default;
-    AdjacentList(usize N) : N{ N }, M{ 0 }, G(N) {}
+    AdjacentList(usize n_) : n{ n_ }, m{}, g(n_) {}
 
     void addDirectedEdge(u32 from, u32 to, const CostType& weight = 1) {
-        G[from].emplace_back(from, to, weight, M++);
+        edges.emplace_back(from, to, weight, m);
+        g[from].emplace_back(from, to, weight, m++);
     }
 
     void addUndirectedEdge(u32 u, u32 v, const CostType& weight = 1) {
-        G[u].emplace_back(u, v, weight, M);
-        G[v].emplace_back(v, u, weight, M++);
+        edges.emplace_back(u, v, weight, m);
+        g[u].emplace_back(u, v, weight, m);
+        g[v].emplace_back(v, u, weight, m++);
     }
 
     inline std::vector<E> operator[](u32 v) {
-        assert(v < N);
-        return G[v];
+        assert(v < n);
+        return g[v];
     }
 
     inline const std::vector<E>& operator[](u32 v) const {
-        assert(v < N);
-        return G[v];
+        assert(v < n);
+        return g[v];
     }
 
     inline usize sizeV() const {
-        return N;
+        return n;
     }
 
     inline usize sizeE() const {
-        return M;
+        return m;
+    }
+
+    inline std::vector<E> enumerateEdges() const {
+        return edges;
+    }
+
+    inline E getEdge(u32 i) const {
+        assert(i < m);
+        return edges[i];
     }
 };
 


### PR DESCRIPTION
# issue番号

- #31 

# 変更内容

- `enumerateEdges`、`getEdge`メソッドを`AdjacentList`に追加
- いくつかのメンバが命名規則を破っていたので、修正

# checklist

- [ ] documentの`documentation_of:` のリンクは間違えて無いですか？
- [ ] documentに誤字脱字衍字はありませんか？
- [ ] `#pragma once`を付けていますか？
- [ ] 関数・クラスは`namespace zawa`下で定義されていますか？
- [ ] 関数・クラスはアッパーキャメルケースで命名されていますか？
- [ ] 不要・不足しているインクルードファイルはありませんか？
- [ ] アンダースコアから始まる変数を用意していませんか？
- [ ] `namespace zawa`の閉じ括弧の方に`// namespace zawa`は入れましたか？
- [ ] gchファイルが残っていませんか？
- [ ] マージしても壊れないという強い確信がありますか？
