### PR TITLE
いくつかのメンバ変数に_をつけた

### DIFF
--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,13 +1,13 @@
 {
-"Test/AOJ/ALDS1_11_B.test.cpp": "2023-06-11 22:24:39 +0900",
-"Test/AOJ/ALDS1_11_D.test.cpp": "2023-06-11 23:05:57 +0900",
+"Test/AOJ/ALDS1_11_B.test.cpp": "2023-06-13 11:49:11 +0900",
+"Test/AOJ/ALDS1_11_D.test.cpp": "2023-06-13 11:49:11 +0900",
 "Test/AtCoder/abc172_c.test.cpp": "2023-06-07 06:12:35 +0900",
 "Test/AtCoder/abc213_c.test.cpp": "2023-06-07 04:27:59 +0900",
-"Test/AtCoder/abc288_c.test.cpp": "2023-06-11 23:05:57 +0900",
-"Test/AtCoder/abc292_d.test.cpp": "2023-06-11 23:05:57 +0900",
-"Test/AtCoder/abc293_d.test.cpp": "2023-06-11 23:05:57 +0900",
+"Test/AtCoder/abc288_c.test.cpp": "2023-06-13 11:49:11 +0900",
+"Test/AtCoder/abc292_d.test.cpp": "2023-06-13 11:49:11 +0900",
+"Test/AtCoder/abc293_d.test.cpp": "2023-06-13 11:49:11 +0900",
 "Test/AtCoder/agc023_a.test.cpp": "2023-06-07 06:12:35 +0900",
 "Test/LC/aplusb.test.cpp": "2023-06-04 17:37:40 +0900",
-"Test/LC/enumerate_primes.test.cpp": "2023-06-06 10:57:42 +0900",
+"Test/LC/enumerate_primes.test.cpp": "2023-06-13 11:55:48 +0900",
 "Test/LC/static_range_sum.test.cpp": "2023-06-07 06:12:35 +0900"
 }

--- a/Docs/Graph/Basis/AdjacentList.md
+++ b/Docs/Graph/Basis/AdjacentList.md
@@ -125,13 +125,19 @@ $i$ 番目に追加した辺を`Edge`構造体で返します。`addUndirectedEd
 
 ## Edge構造体について
 
-以下のようなメンバ変数を持つ構造体です。
+以下のようなメンバを持つクラスです。
 
 ```cpp
-struct Edge {
-    u32 from, to;
-    CostType weight;
-    u32 id;
+class Edge {
+private:
+    u32 from_, to_;
+    CostType weight_;
+    u32 id_;
+public:
+    u32 from() // get from_
+    u32 to() // get to_
+    u32 weight() // get weight_
+    u32 id() // get id_
 };
 ```
 

--- a/Docs/Graph/ConnectedComponents.md
+++ b/Docs/Graph/ConnectedComponents.md
@@ -21,12 +21,12 @@ documentation_of: //Src/Graph/ConnectedComponents.hpp
 #### コンストラクタ
 ```
 (1) ConnectedComponents() = default
-(2) ConnectedComponents(const Graph<CostType& graph_)
+(2) ConnectedComponents(const Graph<CostType& graph)
 ```
 
 (1) デフォルトコンストラクタ
 
-(2) 引数に与えた`graph_`でビルドします。
+(2) 引数に与えた`graph`でビルドします。
 
 具体的には、グラフにある連結成分を以下のように番号付けします。
 - 頂点 $0$ を含む連結成分を $0$ 番とする
@@ -34,7 +34,7 @@ documentation_of: //Src/Graph/ConnectedComponents.hpp
 - $0, 1$ 番の連結成分に含まれていない頂点のうち、番号最小のものを $i_2$ とする。 頂点 $i_2$ を含む連結成分を $2$ 番とする
 - $\vdots$
 
-**制約**: `graph_`が無向グラフであること
+**制約**: `graph`が無向グラフであること
 
 **計算量:** $O(\mid V\mid + \mid E\mid)$
 
@@ -112,7 +112,7 @@ inline u32 getVId(u32 v) const
 inline u32 getEId(u32 v) const
 ```
 
-`graph_`構築時に $v$ 番目に追加された辺が何番目の連結成分に属するかを返します。
+`graph`構築時に $v$ 番目に追加された辺が何番目の連結成分に属するかを返します。
 
 **制約:** $0\ \le v\ \le\ \mid E\mid$
 

--- a/Docs/Number/EratosthenesSieve.md
+++ b/Docs/Number/EratosthenesSieve.md
@@ -14,11 +14,11 @@ documentation_of: "//Src/Number/EratosthenesSieve.hpp"
 #### コンストラクタ
 ```
 (1) EratosthenesSieve()
-(2) EratosthenesSieve(usize tableSize_)
+(2) EratosthenesSieve(usize tableSize)
 ```
 
 (1) デフォルトコンストラクタ  
-(2) $S =$ `tableSize_`として配列を構築します。
+(2) $S =$ `tableSize`として配列を構築します。
 
 **計算量:** $O(S\log (\log S))$
 

--- a/Src/Graph/Basis/AdjacentList.hpp
+++ b/Src/Graph/Basis/AdjacentList.hpp
@@ -8,14 +8,33 @@
 namespace zawa {
 
 template <class CostType>
-struct Edge {
-    u32 from, to;
-    CostType weight;
-    u32 id;
+class Edge {
+private:
+    u32 from_, to_;
+    CostType weight_;
+    u32 id_;
 
+public:
     Edge() = default;
-    Edge(u32 from_, u32 to_, const CostType& weight_, u32 id = -1)
-        : from{ from_ }, to{ to_ }, weight{ weight_ }, id{ id } {}
+    Edge(u32 from, u32 to, const CostType& weight, u32 id)
+        : from_{ from }, to_{ to }, weight_{ weight }, id_{ id } {}
+
+    inline u32 from() const noexcept {
+        return from_;
+    }
+
+    inline u32 to() const noexcept {
+        return to_;
+    }
+
+    inline CostType weight() const {
+        return weight_;
+    }
+
+    inline u32 id() const noexcept {
+        return id_;
+    }
+
 };
 
 template <class CostType>
@@ -23,50 +42,50 @@ class AdjacentList {
 private:
     using E = Edge<CostType>;
 
-    usize n, m;
-    std::vector<E> edges;
-    std::vector<std::vector<E>> g;
+    usize n_, m_;
+    std::vector<E> edges_;
+    std::vector<std::vector<E>> g_;
 
 public:
     AdjacentList() = default;
-    AdjacentList(usize n_) : n{ n_ }, m{}, g(n_) {}
+    AdjacentList(usize n) : n_{ n }, m_{}, g_(n) {}
 
     void addDirectedEdge(u32 from, u32 to, const CostType& weight = 1) {
-        edges.emplace_back(from, to, weight, m);
-        g[from].emplace_back(from, to, weight, m++);
+        edges_.emplace_back(from, to, weight, m_);
+        g_[from].emplace_back(from, to, weight, m_++);
     }
 
     void addUndirectedEdge(u32 u, u32 v, const CostType& weight = 1) {
-        edges.emplace_back(u, v, weight, m);
-        g[u].emplace_back(u, v, weight, m);
-        g[v].emplace_back(v, u, weight, m++);
+        edges_.emplace_back(u, v, weight, m_);
+        g_[u].emplace_back(u, v, weight, m_);
+        g_[v].emplace_back(v, u, weight, m_++);
     }
 
     inline std::vector<E> operator[](u32 v) {
-        assert(v < n);
-        return g[v];
+        assert(v < n_);
+        return g_[v];
     }
 
     inline const std::vector<E>& operator[](u32 v) const {
-        assert(v < n);
-        return g[v];
+        assert(v < n_);
+        return g_[v];
     }
 
-    inline usize sizeV() const {
-        return n;
+    inline usize sizeV() const noexcept {
+        return n_;
     }
 
-    inline usize sizeE() const {
-        return m;
+    inline usize sizeE() const noexcept {
+        return m_;
     }
 
     inline std::vector<E> enumerateEdges() const {
-        return edges;
+        return edges_;
     }
 
     inline E getEdge(u32 i) const {
-        assert(i < m);
-        return edges[i];
+        assert(i < m_);
+        return edges_[i];
     }
 };
 

--- a/Src/Graph/ConnectedComponents.hpp
+++ b/Src/Graph/ConnectedComponents.hpp
@@ -15,22 +15,22 @@ namespace zawa {
 template <class CostType = u32>
 class ConnectedComponents {
 private:
-    Graph<CostType> graph;
-    std::vector<u32> id;
-    usize countComponents;
+    Graph<CostType> graph_;
+    std::vector<u32> id_;
+    usize countComponents_;
 
-    std::vector<std::vector<u32>> componentsV, componentsE;
+    std::vector<std::vector<u32>> componentsV_, componentsE_;
 
 
 public:
     ConnectedComponents() = default;
-    ConnectedComponents(const Graph<CostType>& graph_) 
-        : graph(graph_), id(graph_.sizeV()), countComponents{}, componentsV{}, componentsE{} {
+    ConnectedComponents(const Graph<CostType>& graph) 
+        : graph_(graph), id_(graph.sizeV()), countComponents_{}, componentsV_{}, componentsE_{} {
 
         const u32 inf = std::numeric_limits<u32>::max();
 
-        std::fill(id.begin(), id.end(), inf);
-        id.shrink_to_fit();
+        std::fill(id_.begin(), id_.end(), inf);
+        id_.shrink_to_fit();
 
 
         auto search = [&](u32 s) -> void {
@@ -39,105 +39,105 @@ public:
             while (stk.size()) {
                 auto [v, eid] = stk.top();
                 stk.pop();
-                id[v] = countComponents;
-                for (const auto& e : graph[v]) {
-                    if (id[e.to] == inf) {
-                        stk.push({ e.to, e.id });
+                id_[v] = countComponents_;
+                for (const auto& e : graph_[v]) {
+                    if (id_[e.to()] == inf) {
+                        stk.push({ e.to(), e.id() });
                     }
                 }
             }
         };
 
-        for (u32 i = 0 ; i < graph.sizeV() ; i++) {
-            if (id[i] < inf) continue;
+        for (u32 i = 0 ; i < graph_.sizeV() ; i++) {
+            if (id_[i] < inf) continue;
             search(i);
-            countComponents++;
+            countComponents_++;
         }
 
-        componentsV.resize(countComponents);
-        for (u32 i = 0 ; i < graph.sizeV() ; i++) {
-            componentsV[id[i]].push_back(i);
+        componentsV_.resize(countComponents_);
+        for (u32 i = 0 ; i < graph_.sizeV() ; i++) {
+            componentsV_[id_[i]].push_back(i);
         }
-        componentsV.shrink_to_fit();
-        for (auto& comp : componentsV) {
+        componentsV_.shrink_to_fit();
+        for (auto& comp : componentsV_) {
             comp.shrink_to_fit();
         }
 
-        componentsE.resize(countComponents);
-        for (u32 i = 0 ; i < graph.sizeE() ; i++) {
-            componentsE[id[graph.getEdge(i).from]].push_back(i);
+        componentsE_.resize(countComponents_);
+        for (u32 i = 0 ; i < graph_.sizeE() ; i++) {
+            componentsE_[id_[graph_.getEdge(i).from()]].push_back(i);
         }
-        componentsE.shrink_to_fit();
-        for (auto& comp : componentsE) {
+        componentsE_.shrink_to_fit();
+        for (auto& comp : componentsE_) {
             comp.shrink_to_fit();
         }
     }
 
     inline usize size() const {
-        return countComponents;
+        return countComponents_;
     }
 
     inline usize sizeV(u32 i) const {
-        assert(i < countComponents);
-        return componentsV[i].size();
+        assert(i < countComponents_);
+        return componentsV_[i].size();
     }
 
     inline usize sizeE(u32 i) const {
-        assert(i < countComponents);
-        return componentsE[i].size();
+        assert(i < countComponents_);
+        return componentsE_[i].size();
     }
 
     inline u32 operator[](u32 v) const {
-        assert(v < graph.sizeV());
-        return id[v];
+        assert(v < graph_.sizeV());
+        return id_[v];
     }
 
     inline u32 getVId(u32 v) const {
-        assert(v < graph.sizeV());
-        return id[v];
+        assert(v < graph_.sizeV());
+        return id_[v];
     }   
 
     inline u32 getEId(u32 v) const {
-        assert(v < graph.sizeE());
-        return id[graph.getEdge(v).from];
+        assert(v < graph_.sizeE());
+        return id_[graph_.getEdge(v).from()];
     }   
 
     inline bool same(u32 u, u32 v) const {
-        assert(u < graph.sizeV());
-        assert(v < graph.sizeV());
-        return id[u] == id[v];
+        assert(u < graph_.sizeV());
+        assert(v < graph_.sizeV());
+        return id_[u] == id_[v];
     }
 
     inline std::vector<std::vector<u32>> enumerateV() const {
-        return componentsV;
+        return componentsV_;
     }
 
     inline std::vector<u32> enumerateV(u32 i) const {
-        assert(i < countComponents);
-        return componentsV[i];
+        assert(i < countComponents_);
+        return componentsV_[i];
     }
 
     inline std::vector<std::vector<Edge<CostType>>> enumerateE() const {
-        std::vector res(countComponents, std::vector<Edge<CostType>>());
-        for (u32 i = 0 ; i < countComponents ; i++) {
-            for (auto eid : componentsE[i]) {
-                res[i].push_back(graph.getEdge(eid));
+        std::vector res(countComponents_, std::vector<Edge<CostType>>());
+        for (u32 i = 0 ; i < countComponents_ ; i++) {
+            for (auto eid_ : componentsE_[i]) {
+                res[i].push_back(graph_.getEdge(eid_));
             }
         }
         return res;
     }
 
     inline std::vector<Edge<CostType>> enumerateE(u32 i) const {
-        assert(i < countComponents);
-        std::vector<CostType> res(componentsE[i].size());
-        for (u32 j = 0 ; j < componentsE[i].size() ; j++) {
-            res[j] = graph.getEdge(componentsE[i][j]);
+        assert(i < countComponents_);
+        std::vector<CostType> res(componentsE_[i].size());
+        for (u32 j = 0 ; j < componentsE_[i].size() ; j++) {
+            res[j] = graph_.getEdge(componentsE_[i][j]);
         }
         return res;
     }
 
     inline bool hasCycle(u32 i) const {
-        assert(i < countComponents);
+        assert(i < countComponents_);
         return sizeE(i) + 1 > sizeV(i);
     }
 };

--- a/Src/Number/EratosthenesSieve.hpp
+++ b/Src/Number/EratosthenesSieve.hpp
@@ -10,44 +10,44 @@ namespace zawa {
 
 class EratosthenesSieve {
 private:
-    usize tableSize;
-    std::vector<bool> table;
+    usize tableSize_;
+    std::vector<bool> table_;
 
 public:
     EratosthenesSieve() = default;
 
-    EratosthenesSieve(usize tableSize_) : tableSize{ tableSize_ + 1 }, table(tableSize_ + 1, true) {
-        table.shrink_to_fit();
-        assert(tableSize > 0);
-        table[0] = table[1] = false;
-        for (u64 i = 2 ; i * i < tableSize ; i++) {
-            if (!table[i]) continue;
-            for (u64 j = i * i ; j < tableSize ; j += i ) {
-                table[j] = false;
+    EratosthenesSieve(usize tableSize) : tableSize_{ tableSize + 1 }, table_(tableSize + 1, true) {
+        table_.shrink_to_fit();
+        assert(tableSize_ > 0);
+        table_[0] = table_[1] = false;
+        for (u64 i = 2 ; i * i < tableSize_ ; i++) {
+            if (!table_[i]) continue;
+            for (u64 j = i * i ; j < tableSize_ ; j += i ) {
+                table_[j] = false;
             }
         }
     }
 
     inline bool operator[](u32 i) const {
-        assert(i < tableSize);
-        return table[i];
+        assert(i < tableSize_);
+        return table_[i];
     }
 
     inline bool isPrime(u32 i) const {
-        assert(i < tableSize);
-        return table[i];
+        assert(i < tableSize_);
+        return table_[i];
     }
 
     inline usize size() const {
-        return tableSize - 1;
+        return tableSize_ - 1;
     }
 
     std::vector<u32> enumeratePrimes(u32 N) const {
-        assert(N < tableSize);
+        assert(N < tableSize_);
         std::vector<u32> primes{};
-        primes.reserve(std::count(table.begin(), table.begin() + N + 1, true));
+        primes.reserve(std::count(table_.begin(), table_.begin() + N + 1, true));
         for (u32 i = 2 ; i <= N ; i++) {
-            if (table[i]) {
+            if (table_[i]) {
                 primes.emplace_back(i);
             }
         }

--- a/Test/AOJ/ALDS1_11_B.test.cpp
+++ b/Test/AOJ/ALDS1_11_B.test.cpp
@@ -25,7 +25,7 @@ int main() {
 
     for (u32 i = 0 ; i < N ; i++) {
         for (const auto& e : G[i]) 
-            assert(i == e.from);
+            assert(i == e.from());
     }
 
     std::vector<bool> visited(N);
@@ -35,8 +35,8 @@ int main() {
     auto dfs = [&](auto dfs, u32 v) -> void {
         visited[v] = true;
         d[v] = ++time;
-        for (const auto& e : G[v]) if (!visited[e.to])
-            dfs(dfs, e.to);
+        for (const auto& e : G[v]) if (!visited[e.to()])
+            dfs(dfs, e.to());
         f[v] = ++time;
     };
 


### PR DESCRIPTION
# issue番号

- #34 

# 変更内容

`Graph/Basis/AdjacentList`
`Graph/ConnectedComponents`
`Number/EratosthenesSieve`

のコンストラクタの引数名に`_`がついているものから、`_`を除去する。
代わりにメンバ変数の末尾に`_`を付けた

# checklist

- [ ] documentの`documentation_of:` のリンクは間違えて無いですか？
- [ ] documentに誤字脱字衍字はありませんか？
- [ ] `#pragma once`を付けていますか？
- [ ] 関数・クラスは`namespace zawa`下で定義されていますか？
- [ ] 関数・クラスはアッパーキャメルケースで命名されていますか？
- [ ] 不要・不足しているインクルードファイルはありませんか？
- [ ] アンダースコアから始まる変数を用意していませんか？
- [ ] `namespace zawa`の閉じ括弧の方に`// namespace zawa`は入れましたか？
- [ ] gchファイルが残っていませんか？
- [ ] マージしても壊れないという強い確信がありますか？
