### PR TITLE
Coutの仕様を変更、 Cout -> outにrename

### DIFF
--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,7 +1,7 @@
 {
 "Test/AOJ/ALDS1_11_D.test.cpp": "2023-07-19 15:15:04 +0900",
 "Test/AOJ/GRL_1_A.test.cpp": "2023-08-04 19:12:51 +0900",
-"Test/AOJ/ITP1_1_A.test.cpp": "2023-08-05 12:58:19 +0900",
+"Test/AOJ/ITP1_1_A.test.cpp": "2023-08-07 23:12:03 +0900",
 "Test/AOJ/ITP1_1_C.test.cpp": "2023-08-05 05:25:56 +0900",
 "Test/AOJ/ITP1_2_C.test.cpp": "2023-08-05 04:55:39 +0900",
 "Test/AOJ/ITP2_4_A.test.cpp": "2023-08-05 04:55:39 +0900",
@@ -11,13 +11,13 @@
 "Test/AtCoder/abc247_d.test.cpp": "2023-07-29 13:13:36 +0900",
 "Test/AtCoder/abc288_c.test.cpp": "2023-07-19 15:15:04 +0900",
 "Test/AtCoder/abc292_d.test.cpp": "2023-07-19 15:15:04 +0900",
-"Test/AtCoder/abc293_b.test.cpp": "2023-08-05 06:40:45 +0900",
+"Test/AtCoder/abc293_b.test.cpp": "2023-08-07 23:12:03 +0900",
 "Test/AtCoder/abc293_d.test.cpp": "2023-07-19 15:15:04 +0900",
 "Test/AtCoder/abc295_a.test.cpp": "2023-08-05 06:28:55 +0900",
 "Test/AtCoder/abc299_c.test.cpp": "2023-07-29 13:13:36 +0900",
 "Test/AtCoder/agc023_a.test.cpp": "2023-07-22 13:55:49 +0900",
 "Test/LC/aplusb.test.cpp": "2023-07-17 03:16:46 +0900",
 "Test/LC/enumerate_primes.test.cpp": "2023-06-13 11:55:48 +0900",
-"Test/LC/many_aplusb.test.cpp": "2023-08-05 13:24:43 +0900",
+"Test/LC/many_aplusb.test.cpp": "2023-08-07 23:12:03 +0900",
 "Test/LC/static_range_sum.test.cpp": "2023-07-22 13:55:49 +0900"
 }

--- a/Docs/Template/Output.md
+++ b/Docs/Template/Output.md
@@ -9,28 +9,28 @@ documentation_of: //Src/Template/Output.hpp
 
 ## ライブラリの使い方
 
-#### Cout
+#### out
 
 ```cpp
-(1) void Cout()
-(2) void Cout(const T& value)
-(3) void Cout(const Head& head, const Tail&... tail)
+(1) void out()
+(2) void out(const T& value)
+(3) void out(const Head& head, const Tail&... tail)
 ```
 
 (1) `std::cout << std::endl`と等価です。
 
-(2) `std::cout << value`と等価です。
+(2) `std::cout << value << std::endl`と等価です。
 
-(3) 引数に入れた変数を空白区切りで出力します。最後に改行が入りません。
+(3) 引数に入れた変数を空白区切りで出力します。最後に改行が入ります。
 
 <br />
 
-#### Eout
+#### eout
 
 ```cpp
-(1) void Eout()
-(2) void Eout(const T& value)
-(3) void Eout(const Head& head, const Tail&... tail)
+(1) void eout()
+(2) void eout(const T& value)
+(3) void eout(const Head& head, const Tail&... tail)
 ```
 
 (1) `std::cerr << std::endl`と等価です。

--- a/Src/Template/Output.hpp
+++ b/Src/Template/Output.hpp
@@ -8,39 +8,39 @@
 
 namespace zawa {
 
-void Cout() {
+void out() {
     std::cout << std::endl;
 }
 
 template <class T>
-void Cout(const T& value) {
-    std::cout << value;
+void out(const T& value) {
+    std::cout << value << std::endl;
 }
 
 template <class Head, class... Tail>
-void Cout(const Head& head, const Tail&... tail) {
+void out(const Head& head, const Tail&... tail) {
     std::cout << head;
     if (sizeof...(tail)) {
         std::cout << ' ';
-        Cout(tail...);
     }
+    out(tail...);
 }
 
-void Eout() {
+void eout() {
     std::cerr << std::endl;
 }
 
 template <class T>
-void Eout(const T& value) {
+void eout(const T& value) {
     std::cerr << value;
 }
 
 template <class Head, class... Tail>
-void Eout(const Head& head, const Tail&... tail) {
+void eout(const Head& head, const Tail&... tail) {
     std::cerr << head;
     if (sizeof...(tail)) {
         std::cerr << ' ';
-        Eout(tail...);
+        eout(tail...);
     }
 }
 

--- a/Test/AOJ/ITP1_1_A.test.cpp
+++ b/Test/AOJ/ITP1_1_A.test.cpp
@@ -6,11 +6,11 @@
 using namespace zawa;
 
 int main() {
-    Eout(supi); Eout();
-    Eout(supl); Eout();
-    Eout(infi); Eout();
-    Eout(infl); Eout();
+    eout(supi); eout();
+    eout(supl); eout();
+    eout(infi); eout();
+    eout(infl); eout();
     SetSupi(100);
-    Eout(supi); Eout();
-    Cout("Hello World"); Cout();
+    eout(supi); eout();
+    out("Hello World");
 }

--- a/Test/AtCoder/abc293_b.test.cpp
+++ b/Test/AtCoder/abc293_b.test.cpp
@@ -19,6 +19,6 @@ int main() {
             ans.push_back(i + 1);
         }
     }
-    Cout(ans.size()); Cout();
-    Cout(ans); Cout();
+    out(ans.size());
+    out(ans);
 }

--- a/Test/LC/many_aplusb.test.cpp
+++ b/Test/LC/many_aplusb.test.cpp
@@ -13,6 +13,6 @@ int main() {
     u32 T; In(T);
     for (u32 _{} ; _ < T ; _++) {
         u64 A, B; In(A, B);
-        Cout(A + B, '\n');
+        out(A + B);
     }
 }


### PR DESCRIPTION
# issue番号
- #76 

# 変更内容

- Cout -> outにrename
- Eout -> eoutにrename
- 最後に改行が入るようになった

# checklist

- [ ] documentの`documentation_of:` のリンクは間違えて無いですか？
- [ ] documentに誤字脱字衍字はありませんか？
- [ ] `#pragma once`を付けていますか？
- [ ] 関数・クラスは`namespace zawa`下で定義されていますか？
- [ ] 関数・クラスはアッパーキャメルケースで命名されていますか？
- [ ] 不要・不足しているインクルードファイルはありませんか？
- [ ] アンダースコアから始まる変数を用意していませんか？
- [ ] `namespace zawa`の閉じ括弧の方に`// namespace zawa`は入れましたか？
- [ ] gchファイルが残っていませんか？
- [ ] マージしても壊れないという強い確信がありますか？
