### PR TITLE
zawa::eoutの最後に改行が入るように修正

### DIFF
--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,7 +1,7 @@
 {
 "Test/AOJ/ALDS1_11_D.test.cpp": "2023-07-19 15:15:04 +0900",
 "Test/AOJ/GRL_1_A.test.cpp": "2023-08-04 19:12:51 +0900",
-"Test/AOJ/ITP1_1_A.test.cpp": "2023-08-07 23:12:03 +0900",
+"Test/AOJ/ITP1_1_A.test.cpp": "2023-08-08 12:17:01 +0900",
 "Test/AOJ/ITP1_1_C.test.cpp": "2023-08-05 05:25:56 +0900",
 "Test/AOJ/ITP1_2_C.test.cpp": "2023-08-05 04:55:39 +0900",
 "Test/AOJ/ITP2_4_A.test.cpp": "2023-08-05 04:55:39 +0900",
@@ -11,13 +11,13 @@
 "Test/AtCoder/abc247_d.test.cpp": "2023-07-29 13:13:36 +0900",
 "Test/AtCoder/abc288_c.test.cpp": "2023-07-19 15:15:04 +0900",
 "Test/AtCoder/abc292_d.test.cpp": "2023-07-19 15:15:04 +0900",
-"Test/AtCoder/abc293_b.test.cpp": "2023-08-07 23:12:03 +0900",
+"Test/AtCoder/abc293_b.test.cpp": "2023-08-08 12:17:01 +0900",
 "Test/AtCoder/abc293_d.test.cpp": "2023-07-19 15:15:04 +0900",
 "Test/AtCoder/abc295_a.test.cpp": "2023-08-05 06:28:55 +0900",
 "Test/AtCoder/abc299_c.test.cpp": "2023-07-29 13:13:36 +0900",
 "Test/AtCoder/agc023_a.test.cpp": "2023-07-22 13:55:49 +0900",
 "Test/LC/aplusb.test.cpp": "2023-07-17 03:16:46 +0900",
 "Test/LC/enumerate_primes.test.cpp": "2023-06-13 11:55:48 +0900",
-"Test/LC/many_aplusb.test.cpp": "2023-08-07 23:12:03 +0900",
+"Test/LC/many_aplusb.test.cpp": "2023-08-08 12:17:01 +0900",
 "Test/LC/static_range_sum.test.cpp": "2023-07-22 13:55:49 +0900"
 }

--- a/Docs/Template/Output.md
+++ b/Docs/Template/Output.md
@@ -35,6 +35,6 @@ documentation_of: //Src/Template/Output.hpp
 
 (1) `std::cerr << std::endl`と等価です。
 
-(2) `std::cerr << value`と等価です。
+(2) `std::cerr << value << std::endl;`と等価です。
 
-(3) 引数に入れた変数を空白区切りで標準エラー出力します。最後に改行が入りません。
+(3) 引数に入れた変数を空白区切りで標準エラー出力します。最後に改行はいります。

--- a/Src/Template/Output.hpp
+++ b/Src/Template/Output.hpp
@@ -32,7 +32,7 @@ void eout() {
 
 template <class T>
 void eout(const T& value) {
-    std::cerr << value;
+    std::cerr << value << std::endl;
 }
 
 template <class Head, class... Tail>
@@ -40,8 +40,8 @@ void eout(const Head& head, const Tail&... tail) {
     std::cerr << head;
     if (sizeof...(tail)) {
         std::cerr << ' ';
-        eout(tail...);
     }
+    eout(tail...);
 }
 
 } // namespace zawa

--- a/Test/AOJ/ITP1_1_A.test.cpp
+++ b/Test/AOJ/ITP1_1_A.test.cpp
@@ -6,11 +6,11 @@
 using namespace zawa;
 
 int main() {
-    eout(supi); eout();
-    eout(supl); eout();
-    eout(infi); eout();
-    eout(infl); eout();
+    eout(supi);
+    eout(supl);
+    eout(infi);
+    eout(infl);
     SetSupi(100);
-    eout(supi); eout();
+    eout(supi);
     out("Hello World");
 }


### PR DESCRIPTION
# issue番号
- #15 

# 変更内容

タイトルの通り

# checklist

- [ ] documentの`documentation_of:` のリンクは間違えて無いですか？
- [ ] documentに誤字脱字衍字はありませんか？
- [ ] `#pragma once`を付けていますか？
- [ ] 関数・クラスは`namespace zawa`下で定義されていますか？
- [ ] 関数・クラスはアッパーキャメルケースで命名されていますか？
- [ ] 不要・不足しているインクルードファイルはありませんか？
- [ ] アンダースコアから始まる変数を用意していませんか？
- [ ] `namespace zawa`の閉じ括弧の方に`// namespace zawa`は入れましたか？
- [ ] gchファイルが残っていませんか？
- [ ] マージしても壊れないという強い確信がありますか？
