### PR TITLE
zawa::Inをzawa::inputにrename

### DIFF
--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -18,5 +18,6 @@
 "Test/AtCoder/agc023_a.test.cpp": "2023-07-22 13:55:49 +0900",
 "Test/LC/aplusb.test.cpp": "2023-07-17 03:16:46 +0900",
 "Test/LC/enumerate_primes.test.cpp": "2023-06-13 11:55:48 +0900",
+"Test/LC/many_aplusb.test.cpp": "2023-08-08 12:59:06 +0900",
 "Test/LC/static_range_sum.test.cpp": "2023-07-22 13:55:49 +0900"
 }

--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -11,13 +11,12 @@
 "Test/AtCoder/abc247_d.test.cpp": "2023-07-29 13:13:36 +0900",
 "Test/AtCoder/abc288_c.test.cpp": "2023-07-19 15:15:04 +0900",
 "Test/AtCoder/abc292_d.test.cpp": "2023-07-19 15:15:04 +0900",
-"Test/AtCoder/abc293_b.test.cpp": "2023-08-08 12:17:01 +0900",
+"Test/AtCoder/abc293_b.test.cpp": "2023-08-08 12:55:07 +0900",
 "Test/AtCoder/abc293_d.test.cpp": "2023-07-19 15:15:04 +0900",
-"Test/AtCoder/abc295_a.test.cpp": "2023-08-08 12:38:10 +0900",
+"Test/AtCoder/abc295_a.test.cpp": "2023-08-08 12:55:07 +0900",
 "Test/AtCoder/abc299_c.test.cpp": "2023-07-29 13:13:36 +0900",
 "Test/AtCoder/agc023_a.test.cpp": "2023-07-22 13:55:49 +0900",
 "Test/LC/aplusb.test.cpp": "2023-07-17 03:16:46 +0900",
 "Test/LC/enumerate_primes.test.cpp": "2023-06-13 11:55:48 +0900",
-"Test/LC/many_aplusb.test.cpp": "2023-08-08 12:17:01 +0900",
 "Test/LC/static_range_sum.test.cpp": "2023-07-22 13:55:49 +0900"
 }

--- a/Docs/Template/Input.md
+++ b/Docs/Template/Input.md
@@ -10,11 +10,12 @@ documentation_of: //Src/Template/Input.hpp
 ## ライブラリの使い方
 
 ```cpp
-void In(T& value)
+void input(T& value)
 ```
 
 ```cpp
-void In(Head& head, Tail&... tail)
+void input(Head& head, Tail&... tail)
 ```
 
 標準入力から受け取った値を順に引数の変数に保管します。
+- `std::array`、`std::vector`、`std::pair`の標準入力にも対応しています。

--- a/Src/Template/Input.hpp
+++ b/Src/Template/Input.hpp
@@ -9,14 +9,14 @@
 namespace zawa {
 
 template <class T>
-void In(T& value) {
+void input(T& value) {
     std::cin >> value;
 }
 
 template <class Head, class... Tail>
-void In(Head& head, Tail&... tail) {
-    In(head);
-    In(tail...);
+void input(Head& head, Tail&... tail) {
+    input(head);
+    input(tail...);
 }
 
 } // namespace zawa

--- a/Test/AtCoder/abc293_b.test.cpp
+++ b/Test/AtCoder/abc293_b.test.cpp
@@ -7,10 +7,10 @@
 using namespace zawa;
 
 int main() {
-    u32 N; In(N);
+    u32 N; input(N);
     std::vector<bool> A(N);
     for (u32 i{} ; i < N ; i++) {
-        u32 a; In(a);
+        u32 a; input(a);
         if (not A[i]) A[a - 1] = true;
     }
     std::vector<u32> ans;

--- a/Test/AtCoder/abc295_a.test.cpp
+++ b/Test/AtCoder/abc295_a.test.cpp
@@ -11,11 +11,11 @@ using namespace zawa;
 
 int main() {
     SetAtCoderYesNo();
-    u32 N; In(N);
+    u32 N; input(N);
     std::set<std::string> st{ "and", "not", "that", "the", "you" };
     bool ans{};
     for (u32 _{} ; _ < N ; _++) {
-        std::string w; In(w);
+        std::string w; input(w);
         ans |= st.count(w);
     }
     YesNo(ans);

--- a/Test/LC/many_aplusb.test.cpp
+++ b/Test/LC/many_aplusb.test.cpp
@@ -10,7 +10,7 @@ using namespace zawa;
 int main() {
     SetFastIO();
     SetPrecision(15);
-    u32 T; In(T);
+    u32 T; input(T);
     for (u32 _{} ; _ < T ; _++) {
         u64 A, B; input(A, B);
         out(A + B);

--- a/Test/LC/many_aplusb.test.cpp
+++ b/Test/LC/many_aplusb.test.cpp
@@ -12,7 +12,7 @@ int main() {
     SetPrecision(15);
     u32 T; In(T);
     for (u32 _{} ; _ < T ; _++) {
-        u64 A, B; In(A, B);
+        u64 A, B; input(A, B);
         out(A + B);
     }
 }


### PR DESCRIPTION
# issue番号
- #78 
- #15 

# 変更内容

タイトルの通り。

# checklist

- [ ] documentの`documentation_of:` のリンクは間違えて無いですか？
- [ ] documentに誤字脱字衍字はありませんか？
- [ ] `#pragma once`を付けていますか？
- [ ] 関数・クラスは`namespace zawa`下で定義されていますか？
- [ ] 関数・クラスはアッパーキャメルケースで命名されていますか？
- [ ] 不要・不足しているインクルードファイルはありませんか？
- [ ] アンダースコアから始まる変数を用意していませんか？
- [ ] `namespace zawa`の閉じ括弧の方に`// namespace zawa`は入れましたか？
- [ ] gchファイルが残っていませんか？
- [ ] マージしても壊れないという強い確信がありますか？
