### PR TITLE
Fenwick Treeのoperator<<をクラス定義の中に入れた

### DIFF
--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,7 +1,7 @@
 {
 "Test/AOJ/2957.test.cpp": "2023-08-12 14:28:20 +0900",
 "Test/AOJ/ALDS1_11_D.test.cpp": "2023-07-19 15:15:04 +0900",
-"Test/AOJ/DSL_2_B.test.cpp": "2023-08-23 22:29:14 +0900",
+"Test/AOJ/DSL_2_B.test.cpp": "2023-08-26 19:43:49 +0900",
 "Test/AOJ/GRL_1_A.test.cpp": "2023-08-04 19:12:51 +0900",
 "Test/AOJ/ITP1_1_A.test.cpp": "2023-08-08 12:17:01 +0900",
 "Test/AOJ/ITP1_1_C.test.cpp": "2023-08-05 05:25:56 +0900",
@@ -28,7 +28,7 @@
 "Test/LC/enumerate_primes.test.cpp": "2023-06-13 11:55:48 +0900",
 "Test/LC/enumerate_quotients.test.cpp": "2023-08-14 01:40:44 +0900",
 "Test/LC/many_aplusb.test.cpp": "2023-08-08 12:59:06 +0900",
-"Test/LC/point_add_range_sum.test.cpp": "2023-08-23 22:29:14 +0900",
+"Test/LC/point_add_range_sum.test.cpp": "2023-08-26 19:43:49 +0900",
 "Test/LC/static_range_sum.test.cpp": "2023-07-22 13:55:49 +0900",
 "Test/My/Number/EnumerateQuotients/ceilBuild.test.cpp": "2023-08-12 14:28:20 +0900"
 }

--- a/Docs/DataStructure/FenwickTree/FenwickTree.md
+++ b/Docs/DataStructure/FenwickTree/FenwickTree.md
@@ -164,8 +164,7 @@ u32 minLeft(u32 l, const Function& f) const
 #### operator<<
 
 ```cpp
-template <class Group>
-std::ostream &operator<<(std::ostream& os, const FenwickTree<Group>& ft)
+friend std::ostream& operator<<(std::ostream& os, const FenwickTree& ft)
 ```
 
-$n + 1$ 要素Prefix Productを空白区切りで出力します。
+$n + 1$ 要素空白区切りで出力します。 $i$ 要素目は $\displaystyle \prod_{j = 0}^{i} A_{j}$ を出力します。

--- a/Src/DataStructure/FenwickTree/FenwickTree.hpp
+++ b/Src/DataStructure/FenwickTree/FenwickTree.hpp
@@ -105,7 +105,7 @@ public:
 
     template <class Function>
     u32 minLeft(u32 r, const Function& f) const {
-        static_assert(std::is_convertible_v<decltype(f), std::function<bool(Value)>>, "maxRight's argument f must be function bool(T)");
+        static_assert(std::is_convertible_v<decltype(f), std::function<bool(Value)>>, "minLeft's argument f must be function bool(T)");
         assert(r <= n_);
         Value sum{ product(r) };
         u32 l{};
@@ -121,16 +121,15 @@ public:
         return l;
     }
 
+    // debug print
+    friend std::ostream& operator<<(std::ostream& os, const FenwickTree& ft) {
+        for (u32 i{} ; i <= ft.size() ; i++) {
+            os << ft.product(0, i) << (i == ft.size() ? "" : " ");
+        }
+        return os;
+    }
 
 };
 
-// debug print
-template <class Group>
-std::ostream &operator<<(std::ostream& os, const FenwickTree<Group>& ft) {
-    for (u32 i{} ; i <= ft.size() ; i++) {
-        os << ft.product(0, i) << (i == ft.size() ? "" : " ");
-    }
-    return os;
-}
 
 } // namespace zawa


### PR DESCRIPTION
# issue番号
- #104 

# 変更内容
- Fenwick Treeのoperator<<をクラス定義の中に押し込んだ
- documentも直した
- `minLeft`の`static_assert`のコメント文を修正した

# checklist

- [ ] documentの`documentation_of:` のリンクは間違えて無いですか？
- [ ] documentに誤字脱字衍字はありませんか？
- [ ] `#pragma once`を付けていますか？
- [ ] 関数・クラスは`namespace zawa`下で定義されていますか？
- [ ] 関数・クラスはアッパーキャメルケースで命名されていますか？
- [ ] 不要・不足しているインクルードファイルはありませんか？
- [ ] アンダースコアから始まる変数を用意していませんか？
- [ ] `namespace zawa`の閉じ括弧の方に`// namespace zawa`は入れましたか？
- [ ] gchファイルが残っていませんか？
- [ ] マージしても壊れないという強い確信がありますか？
