### PR TITLE
二項係数のCE問題を解消。modを実行時変数へ #322

### DIFF
--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -113,6 +113,7 @@
 "Test/CF/ECR157-F.test.cpp": "2024-06-25 21:03:43 +0900",
 "Test/CF/ECR167-F.test.cpp": "2024-06-28 18:38:15 +0900",
 "Test/LC/aplusb.test.cpp": "2023-07-17 03:16:46 +0900",
+"Test/LC/binomial_coefficient_prime_mod.test.cpp": "2024-06-30 16:42:17 +0900",
 "Test/LC/bipartitematching.test.cpp": "2023-12-28 22:17:54 +0900",
 "Test/LC/enumerate_primes.test.cpp": "2023-06-13 11:55:48 +0900",
 "Test/LC/enumerate_quotients.test.cpp": "2023-08-14 01:40:44 +0900",
@@ -158,5 +159,5 @@
 "Test/Manual/utpc2012_12.test.cpp": "2024-05-02 00:23:12 +0900",
 "Test/My/Number/EnumerateQuotients/ceilBuild.test.cpp": "2023-08-12 14:28:20 +0900",
 "Test/My/Utility/U32Pair.test.cpp": "2023-12-16 19:11:08 +0900",
-"Test/yukicoder/117.test.cpp": "2024-03-06 21:16:01 +0900"
+"Test/yukicoder/117.test.cpp": "2024-06-30 16:42:17 +0900"
 }

--- a/Docs/Number/BinomalCoefficients.md
+++ b/Docs/Number/BinomalCoefficients.md
@@ -11,30 +11,31 @@ documentation_of: //Src/Number/BinomalCoefficients.hpp
 
 ## ライブラリの使い方
 
-#### テンプレート引数
-
-```cpp
-template <u32 MOD>
-```
-
-`MOD`が素数で無いと`static_assert`に引っかかる。
-
-- `atcoder::internal::is_prime_constexpr`が内部で走る
-
 #### 型
 
 ```cpp
-using Value = atcoder::static_modint<MOD>;
+using Value = atcoder::modint
 ```
+
+dynamic_modintだからちょっと遅いんだよな。うーーーん。流石にAt, ICPCでこれが原因で完数落とすことは無いと信じたいが....
 
 #### コンストラクタ
 
 ```cpp
-(1) BinomalCoefficients()
-(2) BinomalCoefficients(usize n)
+(1) BinomalCoefficients(u32 M)
 ```
 
-予め内部のコンテナをreserveしたい場合は(2)を使用する。 $n \gt 0$ を満たさない場合assertまたは`std::length_error`にひっかかる
+modを $M$ として初期化する。 $M$ が素数でないとき`assert`に引っかかる。
+
+<br />
+
+#### reserve
+
+```cpp
+void reserve(u32 n)
+```
+
+内部のコンテナのサイズを $n$ にする。現在のコンテナのサイズが $n$ より大きいときは何もしない。
 
 <br />
 

--- a/Src/Number/BinomalCoefficients.hpp
+++ b/Src/Number/BinomalCoefficients.hpp
@@ -5,16 +5,17 @@
 #include <cassert>
 #include <cmath>
 #include <vector>
-#include <atcoder/internal_math>
-#include <atcoder/modint>
+#include "atcoder/internal_math.hpp"
+#include "atcoder/modint"
 
 namespace zawa {
 
-template <u32 MOD>
 class BinomalCoefficients {
 public:
-    using Value = atcoder::static_modint<MOD>;
-    static_assert(atcoder::internal::is_prime_constexpr(MOD));
+    using Value = atcoder::modint;
+    u32 mod() const {
+        return Value::mod();
+    }
 private:
     usize n_{};
     std::vector<Value> F_{}, inv_{}, invF_{};
@@ -27,7 +28,7 @@ private:
         invF_.reserve(n + 1);
         for (usize i{n_} ; i <= n ; i++) {
             F_.emplace_back(F_.back() * Value{i});
-            inv_.emplace_back(MOD - inv_[MOD % i] * (MOD / i));
+            inv_.emplace_back(mod() - inv_[mod() % i] * (mod() / i));
             invF_.emplace_back(invF_.back() * inv_.back());
         }
         n_ = n + 1;
@@ -36,16 +37,18 @@ public:
     constexpr usize size() const noexcept {
         return n_;
     }
-    BinomalCoefficients() 
-        : n_{2u}, F_{Value::raw(1), Value::raw(1)}, inv_{Value{}, Value::raw(1)}, 
-        invF_{Value::raw(1), Value::raw(1)} {}
-    BinomalCoefficients(usize n) 
-        : n_{2u}, F_{Value::raw(1), Value::raw(1)}, inv_{Value{}, Value::raw(1)}, 
+    BinomalCoefficients(u32 M) 
+        : n_{2u}, F_{Value::raw(1), Value::raw(1)}, inv_{Value{0}, Value::raw(1)},
         invF_{Value::raw(1), Value::raw(1)} {
-        assert(n);
-        if (need(n)) expand(n);
+            assert(atcoder::internal::is_prime_constexpr(M));
+            Value::set_mod(M);
     }
-    Value F(i32 n) {
+    void reserve(usize newSize) {
+        if (need(newSize)) {
+            expand(newSize);
+        }
+    }
+    Value F(i32 n) noexcept {
         if (need(std::abs(n))) expand(static_cast<usize>(std::abs(n)));
         return (n >= 0 ? F_[n] : invF_[-n]);
     }

--- a/Test/LC/binomial_coefficient_prime_mod.test.cpp
+++ b/Test/LC/binomial_coefficient_prime_mod.test.cpp
@@ -1,0 +1,21 @@
+#define PROBLEM "https://judge.yosupo.jp/problem/binomial_coefficient_prime_mod"
+
+#include "../../Src/Template/IOSetting.hpp"
+#include "../../Src/Number/BinomalCoefficients.hpp"
+
+#include <algorithm>
+#include <iostream>
+
+using namespace zawa;
+
+int main() {
+    int T, m;
+    std::cin >> T >> m;
+    BinomalCoefficients comb(m);
+    comb.reserve(std::min(m, 10000000));
+    while (T--) {
+        int n, k;
+        std::cin >> n >> k;
+        std::cout << comb.C(n, k).val() << '\n';
+    }
+}

--- a/Test/yukicoder/117.test.cpp
+++ b/Test/yukicoder/117.test.cpp
@@ -9,7 +9,6 @@ using namespace zawa;
 
 /*
  * yukicoder No.117 組み合わせの数
- * https://yukicoder.me/submissions/957921
  */
 
 std::tuple<char, int, int> parse() {
@@ -29,7 +28,8 @@ std::tuple<char, int, int> parse() {
 
 void solve() {
     int t; std::cin >> t;
-    BinomalCoefficients<1000000007> comb(1000000);
+    BinomalCoefficients comb(1000000007);
+    comb.reserve(10000000);
     for (int _{} ; _ < t ; _++) {
         auto [c, p, q]{parse()}; 
         if (c == 'C') std::cout << comb.C(p, q).val() << '\n';


### PR DESCRIPTION
# issue番号

- #322 

# 変更内容

# checklist

- [ ] documentの`documentation_of:` のリンクは間違えて無いですか？
- [ ] documentに誤字脱字衍字はありませんか？
- [ ] `#pragma once`を付けていますか？
- [ ] 関数・クラスは`namespace zawa`下で定義されていますか？
- [ ] 関数・クラスはアッパーキャメルケースで命名されていますか？
- [ ] 不要・不足しているインクルードファイルはありませんか？
- [ ] アンダースコアから始まる変数を用意していませんか？
- [ ] `namespace zawa`の閉じ括弧の方に`// namespace zawa`は入れましたか？
- [ ] gchファイルが残っていませんか？
- [ ] マージしても壊れないという強い確信がありますか？
